### PR TITLE
Feature serializer

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -52,7 +52,7 @@ function clickAddMarkerToLayer(layer) {
             dataType: "json",
         })
             .done(function (json) {
-                addMarkerToLayer(digestFeature(json), layer)
+                addMarkerToLayer(json, layer)
             })
     })
 }
@@ -68,23 +68,6 @@ function getSingleState(stateId) {
         })
 }
 
-// Process Fact JSON into GeoJSON feature
-function digestFeature(fact) {
-    var feature = {
-        "type": "Feature",
-        "properties": {
-            "name": fact.title,
-            "amenity": "",
-            "popupContent": fact.details
-        },
-        "geometry": {
-            "type": "Point",
-            "coordinates": [fact.lng, fact.lat]
-        }
-    }
-    return feature
-}
-
 function addMarkerToLayer(feature, layer) {
     L.geoJSON(feature, {
         pointToLayer: function (feat, latlng) {
@@ -97,7 +80,7 @@ function addMarkerToLayer(feature, layer) {
 // Fills select HTML with corresponding state data
 function digestState(json) {
     $("#state-name").html(json.name)
-    $("#state-flag-image").html(json.flag_image)
+    $("#state-flag-image").attr("src", json.flag_image)
     $("#state-description").html(json.description)
     $("#state-capitol").html(json.capitol_name)
     $("#state-population").html(json.population)

--- a/app/controllers/facts_controller.rb
+++ b/app/controllers/facts_controller.rb
@@ -1,7 +1,7 @@
 class FactsController < ApplicationController
   def show
     @fact = Fact.find_by_id(fact_params[:id])
-    render json: @fact
+    render json: FeatureSerializer.new(@fact).to_json
   end
 
   private

--- a/app/serializers/feature_serializer.rb
+++ b/app/serializers/feature_serializer.rb
@@ -1,0 +1,22 @@
+class FeatureSerializer < ActiveModel::Serializer
+  attributes :type, :properties, :geometry
+
+  def type
+    "Feature"
+  end
+
+  def properties
+    {
+      "name": object.title,
+      "amenity": "",
+      "popupContent": object.details
+    }
+  end
+
+  def geometry
+    {
+      "type": "Point",
+      "coordinates": [object.lng, object.lat]
+    }
+  end
+end

--- a/app/serializers/feature_serializer.rb
+++ b/app/serializers/feature_serializer.rb
@@ -7,6 +7,7 @@ class FeatureSerializer < ActiveModel::Serializer
 
   def properties
     {
+      "id": object.id,
       "name": object.title,
       "amenity": "",
       "popupContent": object.details

--- a/spec/requests/fact_request_spec.rb
+++ b/spec/requests/fact_request_spec.rb
@@ -6,16 +6,36 @@ RSpec.describe 'Fact Requests', type: :request do
         @fact = create(:fact)
     end
     describe "GET /facts/:id" do
-        it "returns success with existing ID" do
+        it "returns successful geoJson format with existing ID" do
             get "/facts/#{@fact.id}"
 
             expect(response.status).to eql(200)
             resp = JSON.parse(response.body, symbolize_names: true)
-            expect(resp[:id]).to eql(@fact.id)
-            expect(resp[:title]).to eql(@fact.title)
-            expect(resp[:details]).to eql(@fact.details)
-            expect(resp[:lat]).to eql(@fact.lat)
-            expect(resp[:lng]).to eql(@fact.lng)
+            
+            expect(resp[:type]).to be_present()
+            expect(resp[:type]).to eql('Feature')
+
+            expect(resp[:properties]).to be_present()
+            expect(resp[:properties][:id]).to be_present()
+            expect(resp[:properties][:id]).to eql(@fact.id)
+            expect(resp[:properties][:name]).to be_present()
+            expect(resp[:properties][:name]).to eql(@fact.title)
+            expect(resp[:properties][:amenity]).to eql("")
+            expect(resp[:properties][:popupContent]).to be_present()
+            expect(resp[:properties][:popupContent]).to eql(@fact.details)
+
+            expect(resp[:geometry]).to be_present()
+            expect(resp[:geometry][:type]).to be_present()
+            expect(resp[:geometry][:type]).to eql('Point')
+            expect(resp[:geometry][:coordinates]).to be_present()
+            expect(resp[:geometry][:coordinates][0]).to eql(@fact.lng)
+            expect(resp[:geometry][:coordinates][1]).to eql(@fact.lat)
+
+
+            expect(resp[:title]).to_not be_present()
+            expect(resp[:details]).to_not be_present()
+            expect(resp[:lat]).to_not be_present()
+            expect(resp[:lng]).to_not be_present()
         end
     end
 end


### PR DESCRIPTION
# FeatureSerializer for Server-Side Fact Conversion

This PR:
- Creates the FeatureSerializer, outputs JSON in a geoJSON feature format
- Deletes the JS function digestFeature, which converted the JSON on client-side
- Updates FactRequest spec to account for FeatureSerializer implementation
- Adds Fact ID to feature for future ref (if ever needed)

# How Has This Been Tested?

- RSpec request specs, green path only. Edge cases in future PR.
- All tests passing 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All tests are passing 
- [x] I have added tests that prove my fix is effective or that my feature works